### PR TITLE
chore(deps): update dependency connect-modrewrite to ^0.10.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test-ci": "karma start config/karma.conf.js --single-run"
   },
   "devDependencies": {
-    "connect-modrewrite": "^0.7.9",
+    "connect-modrewrite": "^0.10.1",
     "coveralls": "^2.11.2",
     "front-matter": "^0.2.0",
     "gulp": "^3.8.8",


### PR DESCRIPTION
This Pull Request updates dependency [connect-modrewrite](https://github.com/tinganho/connect-modrewrite) from `^0.7.9` to `^0.10.1`




<details>
<summary>Commits</summary>

#### v0.8.0
-   [`0f78f59`](https://github.com/tinganho/connect-modrewrite/commit/0f78f59e1d7cb7870a73577c0fc9400a974e46e1) 0.8.0
#### v0.8.1
-   [`100b6ce`](https://github.com/tinganho/connect-modrewrite/commit/100b6ce9f2a6509a659fda0fe08ac078cdade045) Adds dash description
-   [`6075afc`](https://github.com/tinganho/connect-modrewrite/commit/6075afc8ead65d320be5534a43670c571085a4a5) 0.8.1
#### v0.8.2
-   [`248a249`](https://github.com/tinganho/connect-modrewrite/commit/248a2495e88babf676b4d8b554debe43de154b95) Tweak to rules regex to only match final square brackets
-   [`bb1852a`](https://github.com/tinganho/connect-modrewrite/commit/bb1852a97a14437957e810b51673e6021ec563c0) Merge pull request #&#8203;51 from jgchristian/only-match-rules-in-final-brackets
#### v0.8.3
-   [`05facc8`](https://github.com/tinganho/connect-modrewrite/commit/05facc8896f210252c7e70312535c78675de9b28) Fixes repo url
-   [`ee2fd93`](https://github.com/tinganho/connect-modrewrite/commit/ee2fd933656e42d2ba7429c1f2e8398a47912653) Update repo URL
-   [`acd2085`](https://github.com/tinganho/connect-modrewrite/commit/acd20858094e73ea4b61ff6cd90771662b9d3f4e) Discard log files
#### v0.8.5
-   [`d9d48c2`](https://github.com/tinganho/connect-modrewrite/commit/d9d48c204f62629e55bd83c778238c7225b3676f) 0.8.3
-   [`e1d2ced`](https://github.com/tinganho/connect-modrewrite/commit/e1d2ced0e3fb723d921c493c455f3786a883c6d1) 0.8.4
-   [`b17be2e`](https://github.com/tinganho/connect-modrewrite/commit/b17be2edbd34be333acfba9966cd4b8908bc7326) 0.8.5
#### v0.9.0
-   [`9f57e9c`](https://github.com/tinganho/connect-modrewrite/commit/9f57e9ccd5ce452b1a334828edbcdd0a93612db5) Trusts proxied https endpoint
-   [`6af5428`](https://github.com/tinganho/connect-modrewrite/commit/6af5428043b0157ba0bdbb9237f9a2328ae5befa) 0.8.6
-   [`d11af54`](https://github.com/tinganho/connect-modrewrite/commit/d11af54363ce09ab1892e3bd3861c58c518fa814) 0.9.0
#### v0.10.1
-   [`dda02d8`](https://github.com/tinganho/connect-modrewrite/commit/dda02d8199f1159478e99fe59a2aadf25afb4927) qs 6.3.1 to address vulnerability
-   [`69cdad3`](https://github.com/tinganho/connect-modrewrite/commit/69cdad3d50c7ca4604ce4e82156feccb0fe6f843) Merge pull request #&#8203;64 from localnerve/master
-   [`73aaec0`](https://github.com/tinganho/connect-modrewrite/commit/73aaec0222cd457d7046d8178d9d91d10100d4f4) 0.10.1
#### v0.10.2
-   [`a6a6163`](https://github.com/tinganho/connect-modrewrite/commit/a6a616341eeb57d44f33bd746216f1881e7b8065) Fixes export * as name syntax
-   [`584266f`](https://github.com/tinganho/connect-modrewrite/commit/584266f52cb5accf5fcfe788a847fcb45d38d74f) Fixes export * as name syntax
-   [`0ad8615`](https://github.com/tinganho/connect-modrewrite/commit/0ad86159ddca2d6a22ff08471f54214106bf8259) 0.10.2

</details>