### PR TITLE
chore(deps): update dependency coveralls to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "devDependencies": {
     "connect-modrewrite": "^0.7.9",
-    "coveralls": "^2.11.2",
+    "coveralls": "^3.0.0",
     "front-matter": "^0.2.0",
     "gulp": "^3.8.8",
     "gulp-autoprefixer": "^1.0.1",


### PR DESCRIPTION
This Pull Request updates dependency [coveralls](https://github.com/nickmerwin/node-coveralls) from `^2.11.2` to `^3.0.0`




<details>
<summary>Commits</summary>

#### v3.0.0
-   [`2ed4d09`](https://github.com/nickmerwin/node-coveralls/commit/2ed4d0958b524f7340ccdb9e87c023b30117f714) major version bump for node &gt; 4.x

</details>