### PR TITLE
chore(deps): update dependency front-matter to ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "connect-modrewrite": "^0.7.9",
     "coveralls": "^2.11.2",
-    "front-matter": "^0.2.0",
+    "front-matter": "^2.0.0",
     "gulp": "^3.8.8",
     "gulp-autoprefixer": "^1.0.1",
     "gulp-concat": "^2.4.1",


### PR DESCRIPTION
This Pull Request updates dependency [front-matter](https://github.com/jxson/front-matter) from `^0.2.0` to `^2.0.0`




<details>
<summary>Commits</summary>

#### v1.0.0
-   [`32e809e`](https://github.com/jxson/front-matter/commit/32e809e56bc3a40ea5bcc9b9f23029c3645e3a13) Moves tests to tape
-   [`2f013f4`](https://github.com/jxson/front-matter/commit/2f013f49ab50c8c303819112d5e418f02fe35073) Adds coverage, coveralls, and tavis config for node 0.12 &amp; iojs
-   [`6ea92d4`](https://github.com/jxson/front-matter/commit/6ea92d4c65423fbe15c5e25bf3fe41e63dad545e) Adds tests for fm.test
-   [`1c43f32`](https://github.com/jxson/front-matter/commit/1c43f32745e92fd13442a4427de77c127283965e) removes node 0.12, coveralls doesn&#x27;t seem to be compatible
-   [`e2b810d`](https://github.com/jxson/front-matter/commit/e2b810dc07ab3e058de66aed5e8031b7acabe899) Adds coveralls badge
-   [`c86403e`](https://github.com/jxson/front-matter/commit/c86403e0951fca57962d48dd2a65d74db57001d6) Uses var instead of const
-   [`22762c1`](https://github.com/jxson/front-matter/commit/22762c1f315d2cf64f912c08625e3aed215ce578) Updates contributors
-   [`f01b06d`](https://github.com/jxson/front-matter/commit/f01b06d7f46365e4c97dd0424208f4beb0a4fbc0) Puts back node 0.12 in the travis config
-   [`bca7424`](https://github.com/jxson/front-matter/commit/bca74246aa6fe92515a8a2631e0895a51c74b94d) 1.0.0
#### v2.0.0
-   [`06a4dcd`](https://github.com/jxson/front-matter/commit/06a4dcd55c78f91780af4f6fcff887d94b0f4f17) Updates coveralls badge
-   [`87ad998`](https://github.com/jxson/front-matter/commit/87ad998b1d4717042c1123756f8d3eca837376a4) Update Node.js versions for travis-ci.
-   [`c798529`](https://github.com/jxson/front-matter/commit/c798529b8f5b90db6562c0621cfd0eceeb763da1) Adds a pre-flight check for a separator on the first line.
-   [`477e8af`](https://github.com/jxson/front-matter/commit/477e8af50e6a3c057cc0a1fe021298a7a2ad8110) Merge pull request #&#8203;27 from jxson/21-fix-non-existing-fm
-   [`17715f4`](https://github.com/jxson/front-matter/commit/17715f4739419175a5257720706a90595a10958e) Adds note about #&#8203;21
-   [`2cb3439`](https://github.com/jxson/front-matter/commit/2cb3439a9773ed5a330bad584d5ec30f7317b211) 2.0.0
#### v2.0.1
-   [`d76704d`](https://github.com/jxson/front-matter/commit/d76704de408321ff9965467d9483ad6295cc79d2) remove leading newlines
-   [`64f352f`](https://github.com/jxson/front-matter/commit/64f352faeaaef3402216be358de45a46564b8f8d) add test case for more complex yaml
-   [`9de8979`](https://github.com/jxson/front-matter/commit/9de89796da00496c6599b50e8dca73540237ca84) switch parser to js-yaml
-   [`2cb0f5b`](https://github.com/jxson/front-matter/commit/2cb0f5baa77847ba1655fbeb8b4d5e3d5caf81ef) Adds @&#8203;slang800 to the contributors list :D
#### v2.0.2
-   [`6fb1dfd`](https://github.com/jxson/front-matter/commit/6fb1dfdf713cad9baa4d1a6506b9ba11f9e13d59) 2.0.1
-   [`cbadb4a`](https://github.com/jxson/front-matter/commit/cbadb4a62c10e45e3195ebfd55a67d2df6ab8bff) Simplify regular expressions.
-   [`a969797`](https://github.com/jxson/front-matter/commit/a969797801a42268e140d050f0500b7179089e01) Adds @&#8203;d10 to the listed contributors
-   [`083d38a`](https://github.com/jxson/front-matter/commit/083d38a2bb35882677f913c5025507ac1c3dddbf) 2.0.2
#### v2.0.3
-   [`37394a3`](https://github.com/jxson/front-matter/commit/37394a30bc460ec5215978c3ae0a33fa29bdf28d) Fixes typo.
-   [`0ee7b2f`](https://github.com/jxson/front-matter/commit/0ee7b2fa2bc7cfb37327bd61cad96c5fc4785a5b) Fixes #&#8203;30
-   [`b4e19a7`](https://github.com/jxson/front-matter/commit/b4e19a7aca88a772925d88d1347c52bb8518216e) Updates coveralls tool
-   [`f7895e2`](https://github.com/jxson/front-matter/commit/f7895e275c5b7b3ccc783e7305ed6b1d7c200926) 2.0.3
#### v2.0.4
-   [`2d66547`](https://github.com/jxson/front-matter/commit/2d66547ec19f7e04108f739627d11af7b9603aa8) Add `attributes` to the returned object when no match is found
-   [`6a2090e`](https://github.com/jxson/front-matter/commit/6a2090e655bb90d9f57e93e6a4c47eadfdd3ab9d) Adds @&#8203;kenlimmj to the contributors list
-   [`c4c30ca`](https://github.com/jxson/front-matter/commit/c4c30ca2eb955acb41f0ae8928cef9b2c29b88a9) 2.0.4
#### v2.0.5
-   [`37c22e6`](https://github.com/jxson/front-matter/commit/37c22e6281cad28866771364dd209fd670a7d245) Use resolution independent SVG images to improve image quality.
-   [`4112ed8`](https://github.com/jxson/front-matter/commit/4112ed8dbe1179ec257755520da3ae833288151d) Merge pull request #&#8203;32 from d10/svg-images
-   [`9be0506`](https://github.com/jxson/front-matter/commit/9be0506d9e2058cac4c7667c93a6e7d76c17122a) 2.0.5
#### v2.0.6
-   [`810457f`](https://github.com/jxson/front-matter/commit/810457feb95b98a3331c29c35a5fd8b5be4677ad) Add support for YAML document end marker
-   [`12e493f`](https://github.com/jxson/front-matter/commit/12e493fd8cfcca2f581126152b1f96ba0ee21342) Format code example
-   [`2e761f1`](https://github.com/jxson/front-matter/commit/2e761f1ce5060edc69f7644d950f6852896836df) Update README.md
-   [`91b0151`](https://github.com/jxson/front-matter/commit/91b0151fe3b0977ae1448b6cd1fe064cf96c33c8) Merge pull request #&#8203;35 from montogeek/patch-1
-   [`6efa6d4`](https://github.com/jxson/front-matter/commit/6efa6d4dbc96ea5e907cf6df94c62aa8e48fa6e3) Merge pull request #&#8203;33 from camoy/master
-   [`71e179b`](https://github.com/jxson/front-matter/commit/71e179ba09e80d785f26ad7709382c05abdde6f2) Adds more folks to the list of contributors.
-   [`28a58a6`](https://github.com/jxson/front-matter/commit/28a58a6e8258713baa2acc4a5ab12b6a5ea80b7e) Updates travis.yml
-   [`821d4d5`](https://github.com/jxson/front-matter/commit/821d4d5df3ed67bf7cc91ba4753d34c2536d1fc3) Reformat travis.yml
-   [`6992edb`](https://github.com/jxson/front-matter/commit/6992edb49555f06a8bde9dfc8e77cc5ac3dd0ed6) Updates nodie.co badge.
-   [`33496f0`](https://github.com/jxson/front-matter/commit/33496f07ba82d10aa2d9f91ada51b48f8905e82a) 2.0.6
#### v2.0.7
-   [`aa9f290`](https://github.com/jxson/front-matter/commit/aa9f290b8ced883a7b111b2c0296598335a57d31) formatting: adds standard for lint and fmt targets
-   [`80af624`](https://github.com/jxson/front-matter/commit/80af624b0d5f6593f8259a11e4a2a091d16282ad) updates badges
-   [`7da3872`](https://github.com/jxson/front-matter/commit/7da38720455f3eefc8543a59b22edf1c2e638804) fornatting: adds more formatting fixes
-   [`a956033`](https://github.com/jxson/front-matter/commit/a95603311d06314d8eb21a8296c290e76cb9d24a) Merge pull request #&#8203;36 from jxson/add-standard
-   [`67a7a2f`](https://github.com/jxson/front-matter/commit/67a7a2f386de14dcf07e22120ed77166254f8499) update readme
-   [`5bf3520`](https://github.com/jxson/front-matter/commit/5bf3520e26317a0e0ff22ccff2bbdca3f612c93c) Merge pull request #&#8203;39 from nswbmw/master
-   [`330c54f`](https://github.com/jxson/front-matter/commit/330c54f8faa3e7c0f28bdc2d7dd5250582e76672) Added browser tests using zool
-   [`e0afbe0`](https://github.com/jxson/front-matter/commit/e0afbe021907b91e0b5ef306600e1bc8ae403572) Lint test code.
-   [`0130d8d`](https://github.com/jxson/front-matter/commit/0130d8d3160cce2a63a729e9fcf9ca7b23bb41c1) Adds Zuul configurations.
-   [`89db7f5`](https://github.com/jxson/front-matter/commit/89db7f5e896d83216b3c23ffb5caccb4f3fc206a) Adds saucelabs badge.
-   [`9208084`](https://github.com/jxson/front-matter/commit/920808492d032eba9f2115980ba4c0e1cb51a2a2) Remove zuul from travis task (for now).
-   [`9484d65`](https://github.com/jxson/front-matter/commit/9484d6559af58203ee5afbbd0edb15a101c07a8e) Adds zuul back to the travis task.
-   [`2ef5c2c`](https://github.com/jxson/front-matter/commit/2ef5c2cfe0648d7d8456b92b4161fd8ff2153723) Attempts to limit saucelabs tests.
-   [`d69e239`](https://github.com/jxson/front-matter/commit/d69e2391f0c8853899b6274d94bbce40f0ae6d87) Adds sauce sub-account.
-   [`63479c1`](https://github.com/jxson/front-matter/commit/63479c1d74e2fd71816f1f264d35a558ceb63502) Adjusting sauce concurrency.
-   [`d602b83`](https://github.com/jxson/front-matter/commit/d602b8398b2fec4bae1236847046bee00f68d5ae) Debugging hanging sauce tests.
-   [`688fe43`](https://github.com/jxson/front-matter/commit/688fe431a82c80957a7eb742b127b798a26efd9a) Maybe this makes a difference?
-   [`813676b`](https://github.com/jxson/front-matter/commit/813676b11b7d3d50bd49e8a61d4bbd5ba7385e6f) Avoid parse error tag:yaml.org,2002:js/function in browser
-   [`788041f`](https://github.com/jxson/front-matter/commit/788041f276c1fa7f601756d5a4c08085856ee30f) Enable all browser tests.
-   [`a251b99`](https://github.com/jxson/front-matter/commit/a251b99297e1e1a127fbab9917ade9a97b54b9b3) Prevent coveralls jank from breaking the build.
-   [`748b19b`](https://github.com/jxson/front-matter/commit/748b19b06372e726fe0b0da5a7976ebfff078ab1) Adds @&#8203;martinheidegger to the contributors list.
-   [`69eb785`](https://github.com/jxson/front-matter/commit/69eb78578a66da8ce387ce612d45a8231bde194b) Merge pull request #&#8203;42 from jxson/add-saucelabs
-   [`9b5c706`](https://github.com/jxson/front-matter/commit/9b5c7068df35e0e703d9d977bb99b1e09d719e6c) Adds test as a dep for release.
-   [`580fab1`](https://github.com/jxson/front-matter/commit/580fab1777f6bd2ea0a81f0cc1fa0768a535d4a2) 2.0.7
#### v2.0.8
-   [`044a49d`](https://github.com/jxson/front-matter/commit/044a49d058a50b9deef8d8bf4770a077582f4c4f) Fixes travis badge to use master branch.
-   [`8a226ea`](https://github.com/jxson/front-matter/commit/8a226ea6003a43874b44e149b9d46b02efd66073) 2.0.8
#### v2.1.0
-   [`0da1e74`](https://github.com/jxson/front-matter/commit/0da1e7481c52aa403c840f7b551c1f35dc919ef2) Add &#x27;yaml&#x27; property to returned &#x27;content&#x27; object.
-   [`997efcf`](https://github.com/jxson/front-matter/commit/997efcfdcdfd20b647d2e23713a89cd6bafc4272) Update README.md
-   [`1ab8e0e`](https://github.com/jxson/front-matter/commit/1ab8e0e925c6d57bd48effbdcf3f722f1a36f886) Rename property to &#x27;frontmatter&#x27;.
-   [`088bd6a`](https://github.com/jxson/front-matter/commit/088bd6a3f56c6b89a6533430476738e8917d9581) Prevent suace tests on PRs (they can&#x27;t access env vars).
-   [`45375c0`](https://github.com/jxson/front-matter/commit/45375c0f080f9be0b0f425daac337de3ae4b9703) Adds @&#8203;aleung to the contributors list.
-   [`d11acb9`](https://github.com/jxson/front-matter/commit/d11acb9a13237f10b43b1825c3fab6313c3c1340) 2.1.0
#### v2.1.1
-   [`b9bd8f1`](https://github.com/jxson/front-matter/commit/b9bd8f1efd2f0b41888526b4825a00aee6c07311) Added code highlighting to README
-   [`0eb6559`](https://github.com/jxson/front-matter/commit/0eb65592d85c83440f119b660c0bf1aa0c1bbfdc) Merge pull request #&#8203;46 from taras/patch-2
#### v2.1.2
-   [`c130dfd`](https://github.com/jxson/front-matter/commit/c130dfd6342e0d51fa32945c3ce36fb84757e063) 2.1.1
-   [`c486b61`](https://github.com/jxson/front-matter/commit/c486b61f2520816b1957c9d4eacf7da9bdd8ae36) Updated regex to only match document boundaries at the start of a line - fixes #&#8203;45
-   [`2ddc5aa`](https://github.com/jxson/front-matter/commit/2ddc5aa222b3deb28868e32d41c052521bfe68bc) Merge pull request #&#8203;47 from kasperpedersen/bug/45-initial-fix
-   [`512bd2c`](https://github.com/jxson/front-matter/commit/512bd2c3ebb5572f0bc67babd694036581df4444) Add @&#8203;kasperpedersen to contrib list :D
-   [`cbdbba0`](https://github.com/jxson/front-matter/commit/cbdbba070ddca85bff25486c264b341ebf979939) 2.1.2
#### v2.2.0
-   [`35f18a0`](https://github.com/jxson/front-matter/commit/35f18a0446b80f6cbb8df7b87f67193aaf04d196) Add a TypeScript declaration file
-   [`9ce82b9`](https://github.com/jxson/front-matter/commit/9ce82b96b9c698942d037611b1db62d8dd7ce4a3) Merge pull request #&#8203;51 from j-f1/patch-1
-   [`8bd6c10`](https://github.com/jxson/front-matter/commit/8bd6c10f67bca337a02501f698970885f83b7fa2) Drop support for old versions in CI
-   [`a12456b`](https://github.com/jxson/front-matter/commit/a12456bdeb2286517b844a8cace289e7999b49bc) 2.2.0
#### v2.3.0
-   [`5b191aa`](https://github.com/jxson/front-matter/commit/5b191aa023e2b51787832ec7130fd084c427cf58) Update js-yaml to latest
-   [`699dac0`](https://github.com/jxson/front-matter/commit/699dac00075279643bf5ac7eb9a511550c74fc54) Merge pull request #&#8203;52 from camden/patch-1
-   [`045a187`](https://github.com/jxson/front-matter/commit/045a187d765711ec42538f444dfcfd35c3c06d88) 2.3.0

</details>