### PR TITLE
chore(deps): update dependency gulp-autoprefixer to ^5.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "coveralls": "^2.11.2",
     "front-matter": "^0.2.0",
     "gulp": "^3.8.8",
-    "gulp-autoprefixer": "^1.0.1",
+    "gulp-autoprefixer": "^5.0.0",
     "gulp-concat": "^2.4.1",
     "gulp-connect": "^2.0.6",
     "gulp-coveralls": "^0.1.3",


### PR DESCRIPTION
This Pull Request updates dependency [gulp-autoprefixer](https://github.com/sindresorhus/gulp-autoprefixer) from `^1.0.1` to `^5.0.0`



<details>
<summary>Release Notes</summary>

### [`v2.0.0`](https://github.com/sindresorhus/gulp-autoprefixer/releases/v2.0.0)

[autoprefixer-core changelog](https://github.com/postcss/autoprefixer-core/blob/master/ChangeLog.md#&#8203;40-indivisibiliter-ac-inseparabiliter)

---

</details>


<details>
<summary>Commits</summary>

#### v2.0.0
-   [`fd6fb56`](https://github.com/sindresorhus/gulp-autoprefixer/commit/fd6fb56029630a938641fcde8933ccb36732132d) 1.0.1
-   [`9956500`](https://github.com/sindresorhus/gulp-autoprefixer/commit/99565007a802cc69b7c8c1b424ddbd92b29e7597) bump to autoprefixer-core 4.0.0
-   [`5cee824`](https://github.com/sindresorhus/gulp-autoprefixer/commit/5cee82437ffcafb408e8991d242b2d464cc7d46c) add test to make sure it reads upstream source maps
-   [`e96e7a2`](https://github.com/sindresorhus/gulp-autoprefixer/commit/e96e7a2aaa66814680c0c68bdd50d517d54b89cf) minor tweaks
-   [`b6b0c8d`](https://github.com/sindresorhus/gulp-autoprefixer/commit/b6b0c8d876d110163b68e0004a617fbee10edf3f) 2.0.0
#### v2.1.0
-   [`f6498a3`](https://github.com/sindresorhus/gulp-autoprefixer/commit/f6498a366b14b33510b82af0efec4e762e7b979d) Update readme.md
-   [`70cda12`](https://github.com/sindresorhus/gulp-autoprefixer/commit/70cda120ea3942c8c11145ad6b188549d11a6e37) bump autoprefixer to 5.0.0
-   [`96ac1e5`](https://github.com/sindresorhus/gulp-autoprefixer/commit/96ac1e575b8fb3602239916bcd9fd575dcb98ad9) 2.1.0
#### v2.2.0
-   [`fe899ec`](https://github.com/sindresorhus/gulp-autoprefixer/commit/fe899ec17ab4a87508821304b8bb5d5b38013643) Update .travis.yml
-   [`f40a22a`](https://github.com/sindresorhus/gulp-autoprefixer/commit/f40a22a62c28f3f0279bf59aeadea2be6819902a) Adhere to runner guidelines
-   [`fe59a19`](https://github.com/sindresorhus/gulp-autoprefixer/commit/fe59a191343869b542221045ed6b9b286cb38ebf) Merge pull request #&#8203;29 from sindresorhus/guidelines
-   [`e64b755`](https://github.com/sindresorhus/gulp-autoprefixer/commit/e64b7553879fbf6af41be3772cb2f39f578690bf) minor tweaks
-   [`8cce106`](https://github.com/sindresorhus/gulp-autoprefixer/commit/8cce1060bd2cfa7d96d0e3e481c2927c5f5215ca) 2.2.0
#### v2.3.0
-   [`27356c1`](https://github.com/sindresorhus/gulp-autoprefixer/commit/27356c171f5baca1d81bfa0b80af986b636adc8a) remove moot code
-   [`27b81ad`](https://github.com/sindresorhus/gulp-autoprefixer/commit/27b81add0388827f9fb38ceed2e5630ebdd397ed) update postcss keyword
-   [`834f7ea`](https://github.com/sindresorhus/gulp-autoprefixer/commit/834f7ea9ee5e2b994c33f020773f78e423d5e48f) simplify error handling and improve warnings output
-   [`e2bab2b`](https://github.com/sindresorhus/gulp-autoprefixer/commit/e2bab2be08dfd4e60b18525d319cf1f375603cac) 2.3.0
#### v2.3.1
-   [`53ad3c2`](https://github.com/sindresorhus/gulp-autoprefixer/commit/53ad3c27aded781383ad1ca54914a6583b1fd12b) prevent stream unhandled exception from being suppressed by Promise
-   [`02d7766`](https://github.com/sindresorhus/gulp-autoprefixer/commit/02d77661de48890facdf98e1061400264d4f5ef8) 2.3.1
#### v3.0.0
-   [`a5f34c4`](https://github.com/sindresorhus/gulp-autoprefixer/commit/a5f34c41b58c24dbc9335d40f815f1f11410f428) autoprefixer@&#8203;6.0.0
-   [`7bda96e`](https://github.com/sindresorhus/gulp-autoprefixer/commit/7bda96e03e07d359c050bea72c3b6f70bd4a849f) add XO
-   [`4b7c43b`](https://github.com/sindresorhus/gulp-autoprefixer/commit/4b7c43b3262cf0b71ee820ad339a5e2be3e3e2e8) 3.0.0
#### v3.0.1
-   [`88757c5`](https://github.com/sindresorhus/gulp-autoprefixer/commit/88757c5d0a75b882a36c87c21270451598ed101a) remove Node.js 0.10 support
-   [`7d4f8b8`](https://github.com/sindresorhus/gulp-autoprefixer/commit/7d4f8b86fe612661efebfcd3e1683492f5412d45) 3.0.1
#### v3.0.2
-   [`f1ea075`](https://github.com/sindresorhus/gulp-autoprefixer/commit/f1ea075c066655ed462b2eb3e21be4693aa9cd21) travis - test on Node.js 4
-   [`24ed6a4`](https://github.com/sindresorhus/gulp-autoprefixer/commit/24ed6a4c78a43d00fdbbae82a130d9436f9174cf) minor tweaks
-   [`249cec5`](https://github.com/sindresorhus/gulp-autoprefixer/commit/249cec56e591a985216f1a426928900b326933cf) 3.0.2
#### v3.1.0
-   [`5923c61`](https://github.com/sindresorhus/gulp-autoprefixer/commit/5923c61967b02fe99843027e448520a51383d988) bump deps
-   [`8cc62f4`](https://github.com/sindresorhus/gulp-autoprefixer/commit/8cc62f4fa3c8bc8ab1efe2c59fe7c13ee5c7b652) 3.1.0
#### v3.1.1
-   [`fb035b5`](https://github.com/sindresorhus/gulp-autoprefixer/commit/fb035b5f70440693e8cc86f09daf975f9d8a3dc0) add tip about PostCSS plugins
-   [`324ff05`](https://github.com/sindresorhus/gulp-autoprefixer/commit/324ff05ffc9e45211a40f7aa2ac5127075378a18) minor tweaks
-   [`f6a972d`](https://github.com/sindresorhus/gulp-autoprefixer/commit/f6a972da13e0e772fe80ee1d3d0c5ae158780104) trying out something new
-   [`a276609`](https://github.com/sindresorhus/gulp-autoprefixer/commit/a276609e9c3824f163435aaf2488f926eb1daba3) 3.1.1
#### v4.0.0
-   [`90f8f7c`](https://github.com/sindresorhus/gulp-autoprefixer/commit/90f8f7c819b08869a2a4eb8c50e9684ab36821b5) Improve the tip (#&#8203;75)
-   [`cd022c8`](https://github.com/sindresorhus/gulp-autoprefixer/commit/cd022c87d953222feabcd1e50d1cc6e3b07d4292) Fix tests
-   [`0a92d79`](https://github.com/sindresorhus/gulp-autoprefixer/commit/0a92d793433567a55eae592ec23c4a78d75d9478) Update to Autoprefixer 7 (#&#8203;80)
-   [`7df69ba`](https://github.com/sindresorhus/gulp-autoprefixer/commit/7df69baf6c7f9c362c737ccfa6a64fd1b270171f) ES2015ify, bump postcss, require Node.js 4
-   [`04814b7`](https://github.com/sindresorhus/gulp-autoprefixer/commit/04814b718248cc2a43fcf298aebf71e76bbd8047) Rewrite tests to use AVA
-   [`5188604`](https://github.com/sindresorhus/gulp-autoprefixer/commit/51886049f1b2bf1e3ac0631ef2a48137f4acfe10) 4.0.0
#### v4.1.0
-   [`60aead3`](https://github.com/sindresorhus/gulp-autoprefixer/commit/60aead3f9dd4f8467452ef8df49aeacbf62eed3f) Test against Node.js v8 (#&#8203;90)
-   [`94f3447`](https://github.com/sindresorhus/gulp-autoprefixer/commit/94f3447f891cfb8132f22ebffc4747e051c18eb8) Drop dependency on deprecated gulp-util (#&#8203;94)
-   [`27816c3`](https://github.com/sindresorhus/gulp-autoprefixer/commit/27816c328df5b38ae3de35884aceea4dc045107b) Meta tweaks
-   [`d008588`](https://github.com/sindresorhus/gulp-autoprefixer/commit/d008588d84737dcc39e3595a76bad55f493b62c4) 4.1.0
#### v5.0.0
-   [`7828646`](https://github.com/sindresorhus/gulp-autoprefixer/commit/78286463a149aa6d77be29e2a8f2ea878ebe2cf1) Upgrade to Autoprefixer 8 (#&#8203;96)
-   [`e954e6e`](https://github.com/sindresorhus/gulp-autoprefixer/commit/e954e6e8044fcfe2dcd54d1d40333aa681b84808) Update sourcemap paths to be relative to `file.base` (#&#8203;92)
-   [`e526a78`](https://github.com/sindresorhus/gulp-autoprefixer/commit/e526a78c1a7a9747a5dabe414d7284c155afa07d) Meta tweaks
-   [`18a27be`](https://github.com/sindresorhus/gulp-autoprefixer/commit/18a27bedc5c0f6bbbba6520b26a1e104f5361f6c) 5.0.0

</details>