### PR TITLE
chore(deps): update dependency jasmine-core to ^3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "gulp-ruby-sass": "^0.7.1",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
-    "jasmine-core": "^2.1.3",
+    "jasmine-core": "^3.0.0",
     "karma": "^0.12.28",
     "karma-coverage": "^0.2.7",
     "karma-coveralls": "^0.1.4",


### PR DESCRIPTION
This Pull Request updates dependency [jasmine-core](https://github.com/jasmine/jasmine) from `^2.1.3` to `^3.0.0`



<details>
<summary>Release Notes</summary>

### [`v3.0.0`](https://github.com/jasmine/jasmine/releases/v3.0.0)

Please see the [release notes](https://github.com/jasmine/jasmine/blob/master/release_notes/3.0.md)

---

### [`v3.1.0`](https://github.com/jasmine/jasmine/releases/v3.1.0)

Please see the [release notes](https://github.com/jasmine/jasmine/blob/master/release_notes/3.1.0.md)

---

</details>


<details>
<summary>Commits</summary>

#### v3.0.0
-   [`516fe68`](https://github.com/jasmine/jasmine/commit/516fe6875959dffde38cd512f1b19af9a862f98c) Merge branch &#x27;3.0-features&#x27;
#### v3.1.0
-   [`a8a5b83`](https://github.com/jasmine/jasmine/commit/a8a5b839abf524fb6f55e7d875b5009d9385f962) allow adding a deprecation object
-   [`c859128`](https://github.com/jasmine/jasmine/commit/c859128537e9e5a8c48f5b5634b446f7a8f2b937) add tests
-   [`1d49558`](https://github.com/jasmine/jasmine/commit/1d495587ff6aa261b1a7c83a2cb201773583f414) Fix release note typo
-   [`4fcd409`](https://github.com/jasmine/jasmine/commit/4fcd4099ad9c63c934a6c2b9bd44205fb4fb6275) Resolve merge conflict
-   [`c861f6c`](https://github.com/jasmine/jasmine/commit/c861f6c6c2a83b830eb741cd4c4c1073c1d54023) Merge pull request #&#8203;1499 from bcaudan/patch-1
-   [`fa6a80b`](https://github.com/jasmine/jasmine/commit/fa6a80b76e388fcab82c9ef88e58d4080233c5f8) Merge branch &#x27;master&#x27; of https://github.com/aptx4869/jasmine into aptx4869-master
-   [`6193bc1`](https://github.com/jasmine/jasmine/commit/6193bc113b613f83dfeb48e958f5a46c9eb75585) throw errors
-   [`3c6308f`](https://github.com/jasmine/jasmine/commit/3c6308f1dc0087f0c6a63ff5c135f3506155b798) Don&#x27;t include the specs in the ruby gem
-   [`83beca6`](https://github.com/jasmine/jasmine/commit/83beca689972c06fbe66c57691c35fce608a013a) Merge branch &#x27;2.99-patch&#x27;
-   [`148d945`](https://github.com/jasmine/jasmine/commit/148d94558d76236e9b3b9df0660eb0f21f4e8232) Add CodeTriage badge to jasmine/jasmine
-   [`cd6a0de`](https://github.com/jasmine/jasmine/commit/cd6a0de852901ed3023e40ea7a250d3bf08c6762) Merge pull request #&#8203;1505 from codetriage-readme-bot/codetriage-badge
-   [`8326ecf`](https://github.com/jasmine/jasmine/commit/8326ecf9197a592851bfe64c02bd3c9233a043dc) Merge branch &#x27;deprecation-object&#x27; of https://github.com/UziTech/jasmine into UziTech-deprecation-object
-   [`1182757`](https://github.com/jasmine/jasmine/commit/11827572d3d1cdc1b7def1440ba3a8586a77d3f4) Moved toHaveClass matcher into core so that it can be used in Karma
-   [`3b77f38`](https://github.com/jasmine/jasmine/commit/3b77f3818846ea68bcdcd7b0b734b48cb1f69cc1) Return &lt;anonymous&gt; for functions that have no actual words between keyword and (
-   [`2b27bd3`](https://github.com/jasmine/jasmine/commit/2b27bd393fce42966380b6a0f5e5f40d7014af96) Add API docs for async reporters
-   [`c974c47`](https://github.com/jasmine/jasmine/commit/c974c4740c3e762666c913a52f3fd3b5bb93490b) Merge branch &#x27;master&#x27; of https://github.com/sjolicoeur/jasmine into sjolicoeur-master
-   [`d8c154a`](https://github.com/jasmine/jasmine/commit/d8c154a2c66c5749b99f41dd58473d1885983359) Update empty and notEmpty specs for better IE11 support
-   [`785f62c`](https://github.com/jasmine/jasmine/commit/785f62c7a06767df1124e7b6877637ec5c234fe3) Fix naming and check functions for empty/notEmpty specs
-   [`1ac2a6f`](https://github.com/jasmine/jasmine/commit/1ac2a6f608ec5f542e8b532d881d533da62c031c) Allow node to report load time errors
-   [`0184808`](https://github.com/jasmine/jasmine/commit/0184808a86fc8935b76acf4d8ba813d627102874) Updated README for 3.0
-   [`a9a112e`](https://github.com/jasmine/jasmine/commit/a9a112e88f16f085c454a4948a97e87524e501d0) Fixed release notes link
-   [`7fb53dc`](https://github.com/jasmine/jasmine/commit/7fb53dcdfa2dcf83682361a3cf160717be8a0d93) Fixing missing semi-colons
-   [`763a83c`](https://github.com/jasmine/jasmine/commit/763a83c83313a55cb531041c3d184b020fe3e174) Display error properties for failed specs
-   [`0367ca5`](https://github.com/jasmine/jasmine/commit/0367ca529475935700c7f9d0681e60c021f5c3ec) Merge branch &#x27;patch-closing-statement&#x27; of https://github.com/Sylhare/jasmine
-   [`9ee85c3`](https://github.com/jasmine/jasmine/commit/9ee85c35d2926c26fff1383914512c9cc71b6404) Remove duplicate ignored property
-   [`1149d4e`](https://github.com/jasmine/jasmine/commit/1149d4edde73abd7aaf396c2bccd037ea9dea160) Use j$.pp instead of JSON.stringify() for pretty printing
-   [`11f4d89`](https://github.com/jasmine/jasmine/commit/11f4d894a65826d059326fa695671ee9b6ae5cc3) Merge branch &#x27;node-load-errors&#x27;
-   [`fdecf02`](https://github.com/jasmine/jasmine/commit/fdecf02472d88ab0204fec92c351faf51800f9ee) Merge branch &#x27;print_exception_properties&#x27; of https://github.com/jbunton-atlassian/jasmine into jbunton-atlassian-print_exception_properties
-   [`63cc7ca`](https://github.com/jasmine/jasmine/commit/63cc7cafc807f939eecf672f82aec1c625e139db) Use Jasmine&#x27;s arrayContains, instead of includes for better support
-   [`71116d3`](https://github.com/jasmine/jasmine/commit/71116d3957280c80ce84657a24d39ed9a1dc63e0) don&#x27;t lock to 2.99 in dev
-   [`1923461`](https://github.com/jasmine/jasmine/commit/1923461b094f3cec341d2dc964d9ba0680d3b13d) Ignore more browser fields when formatting Errors
-   [`91296a4`](https://github.com/jasmine/jasmine/commit/91296a44f276e02b575c9b36f7f0d20b98a3feba) Remove Safari 7 from Travis matrix
-   [`ee52023`](https://github.com/jasmine/jasmine/commit/ee52023b3dba0e58ed4dab8db438dde0e5062d62) Bump version to 3.1
-   [`557fb4e`](https://github.com/jasmine/jasmine/commit/557fb4ed7247728aee5a15a2c9d4b9a91563a47d) proper links in release notes

</details>