### PR TITLE
chore(deps): update dependency run-sequence to ^2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "lcov-filter": "0.0.1",
     "rimraf": "^2.2.8",
-    "run-sequence": "^1.0.1",
+    "run-sequence": "^2.0.0",
     "through2": "^0.6.2"
   },
   "private": true


### PR DESCRIPTION
This Pull Request updates dependency [run-sequence](https://github.com/OverZealous/run-sequence) from `^1.0.1` to `^2.0.0`



<details>
<summary>Release Notes</summary>

### [`v2.0.0`](https://github.com/OverZealous/run-sequence/blob/master/CHANGELOG.md#&#8203;200httpsgithubcomOverZealousrun-sequencereleasestagv200---2017-06-30)

##### Changed

- Specified version numbers for all dependencies, due to Chalk dropping support for older Node versions

  This may be a **breaking change** if you depend on a newer release of any dependency, so you can continue using 1.2.2 in that case.

---

### [`v2.1.0`](https://github.com/OverZealous/run-sequence/blob/master/CHANGELOG.md#&#8203;210httpsgithubcomOverZealousrun-sequencereleasestagv210---2017-07-24)

##### Changed

- Added options object
    - Added option for reduced stack trace reporting
    - Added option to ignore falsey task names

---

### [`v2.2.0`](https://github.com/OverZealous/run-sequence/blob/master/CHANGELOG.md#&#8203;221httpsgithubcomOverZealousrun-sequencereleasestagv220---2018-01-03)

##### Changed

- Replaced deprecated `gulp-util` with individual packages, thanks to [@&#8203;demurgos]

---

### [`v2.2.1`](https://github.com/OverZealous/run-sequence/blob/master/CHANGELOG.md#&#8203;221httpsgithubcomOverZealousrun-sequencereleasestagv220---2018-01-03)

##### Changed

- Replaced deprecated `gulp-util` with individual packages, thanks to [@&#8203;demurgos]

---

</details>


<details>
<summary>Commits</summary>

#### v2.0.0
-   [`ee04d48`](https://github.com/OverZealous/run-sequence/commit/ee04d4851f3c68f160c98d0504c7c7b6b5ebfb86) Added modern node versions to travis ci (#&#8203;73)
-   [`b83cc34`](https://github.com/OverZealous/run-sequence/commit/b83cc34cecd5ee4d3c0458be8f60988baeabaf8f) Adding Yarn lockfile
-   [`7e263af`](https://github.com/OverZealous/run-sequence/commit/7e263affdc0a657c0fedcbb5230d3a8734f08643) Ignore yarn lock when publishing
-   [`59515cf`](https://github.com/OverZealous/run-sequence/commit/59515cf296e1bb3d37e60c72add907dc4a21f009) Fixed typo
-   [`d80ddf5`](https://github.com/OverZealous/run-sequence/commit/d80ddf538f32f29d67045f36f6e63e66c0b9cffe) Specify chalk version (#&#8203;89)
#### v2.1.0
-   [`9fd7783`](https://github.com/OverZealous/run-sequence/commit/9fd7783f0f756ba6fb5a36049507422d8f91d95b) 2.0.0
-   [`578d017`](https://github.com/OverZealous/run-sequence/commit/578d01790538e298cb83dc82ab4c19bcf30b3df4) Added a changelog, Closes #&#8203;82
-   [`f2b1635`](https://github.com/OverZealous/run-sequence/commit/f2b16350968ccabf3711dde1f14f007f884369bb) Added options, code cleanup
-   [`dada3f4`](https://github.com/OverZealous/run-sequence/commit/dada3f4d3078352626ca7eafe4e386a92a97575e) Added date to v1 in changelog
-   [`066b8c6`](https://github.com/OverZealous/run-sequence/commit/066b8c657ee9a8677713c25f32380c15207d693c) 2.1.0
#### v2.2.0
-   [`2155560`](https://github.com/OverZealous/run-sequence/commit/21555608ef21ad91b660b1da8fc78d6f9f8c6111) handle orchestration aborted events (#&#8203;97)
-   [`c450122`](https://github.com/OverZealous/run-sequence/commit/c450122365b3342eca6c4853de750ed5f1091687) Changelog, cleanup for orchestration events change
-   [`37e17be`](https://github.com/OverZealous/run-sequence/commit/37e17be41a0e40771cd7eb8cdc474370b150f2ce) 2.2.0
#### v2.2.1
-   [`209e46c`](https://github.com/OverZealous/run-sequence/commit/209e46cac0aca3899bc9d0c7b0f7d19b338d233b) Drop dependency on deprecated `gulp-util` (#&#8203;100)
-   [`31103da`](https://github.com/OverZealous/run-sequence/commit/31103da22f2e06a1b66af8fd7bee22d9a1ba0da1) 2.2.1

</details>